### PR TITLE
fix incorrect timer triggering (twice) for libff

### DIFF
--- a/deps/libff/libff/ff-timer.c
+++ b/deps/libff/libff/ff-timer.c
@@ -51,6 +51,9 @@ static void *timer_thread(void *opaque)
 						- current_time));
 			}
 
+			pthread_mutex_unlock(&timer->mutex);
+			continue;
+
 			// we can be woken up merely to set a sooner wake time
 
 		} else {


### PR DESCRIPTION
I found sometimes the timer will be triggered twice in one request.
GIF in this issue will be rendered in wrong speed.
(replay more easily for fast computer)